### PR TITLE
fix(composer-cache-dir): use working-directory input to get composer cache dir

### DIFF
--- a/__tests__/utils/getCacheKeys.test.ts
+++ b/__tests__/utils/getCacheKeys.test.ts
@@ -1,4 +1,5 @@
 import {getCacheKeys} from '../../src/utils'
+import * as utils from '../../src/utils'
 
 jest.mock('@actions/core')
 
@@ -30,6 +31,7 @@ describe('cache keys', () => {
       key: 'fooplatform-php-7.99.99-locked-foobar-',
       restoreKeys: ['fooplatform-php-7.99.99-locked-foobar-', 'fooplatform-php-7.99.99-locked-']
     })
+    expect(utils.hashFiles).toHaveBeenCalledWith('composer.json\ncomposer.lock');
   })
 
   test('returns cache keys WITH dependency-versions but WITHOUT composer-options and working-directory', async () => {
@@ -37,6 +39,7 @@ describe('cache keys', () => {
       key: 'fooplatform-php-7.99.99-lowest-foobar-',
       restoreKeys: ['fooplatform-php-7.99.99-lowest-foobar-', 'fooplatform-php-7.99.99-lowest-']
     })
+    expect(utils.hashFiles).toHaveBeenCalledWith('composer.json\ncomposer.lock');
   })
 
   test('returns cache keys WITH dependency-versions and composer-options but WITHOUT working-directory', async () => {
@@ -46,6 +49,7 @@ describe('cache keys', () => {
       key: 'fooplatform-php-7.99.99-highest-foobar---some-other-option --and-another',
       restoreKeys: ['fooplatform-php-7.99.99-highest-foobar-', 'fooplatform-php-7.99.99-highest-']
     })
+    expect(utils.hashFiles).toHaveBeenCalledWith('composer.json\ncomposer.lock');
   })
 
   test('returns cache keys WITH dependency-versions and composer-options and working-directory', async () => {
@@ -55,5 +59,6 @@ describe('cache keys', () => {
       key: 'fooplatform-php-7.99.99-subdirectory-highest-foobar---some-other-option --and-another',
       restoreKeys: ['fooplatform-php-7.99.99-subdirectory-highest-foobar-', 'fooplatform-php-7.99.99-subdirectory-highest-']
     })
+    expect(utils.hashFiles).toHaveBeenCalledWith('subdirectory/composer.json\nsubdirectory/composer.lock');
   })
 })

--- a/__tests__/utils/getComposerCacheDir.test.ts
+++ b/__tests__/utils/getComposerCacheDir.test.ts
@@ -13,25 +13,7 @@ describe('getComposerCacheDir with mocked exec', () => {
     expect(execMock).toHaveBeenCalledTimes(1)
     expect(execMock).toHaveBeenCalledWith(
       'composer',
-      ['config', 'cache-dir'],
-      expect.objectContaining({
-        silent: true,
-        listeners: {
-          stdout: expect.any(Function)
-        }
-      })
-    )
-  })
-
-  test('executes command to get Composer cache directory with a working directory', async () => {
-    const execMock = jest.spyOn(exec, 'exec')
-
-    await getComposerCacheDir('subdirectory')
-
-    expect(execMock).toHaveBeenCalledTimes(1)
-    expect(execMock).toHaveBeenCalledWith(
-      'composer',
-      ['config', 'cache-dir', '--working-dir=subdirectory'],
+      ['--global', 'config', 'cache-dir'],
       expect.objectContaining({
         silent: true,
         listeners: {

--- a/__tests__/utils/getComposerCacheDir.test.ts
+++ b/__tests__/utils/getComposerCacheDir.test.ts
@@ -22,4 +22,22 @@ describe('getComposerCacheDir with mocked exec', () => {
       })
     )
   })
+
+  test('executes command to get Composer cache directory with a working directory', async () => {
+    const execMock = jest.spyOn(exec, 'exec')
+
+    await getComposerCacheDir('subdirectory')
+
+    expect(execMock).toHaveBeenCalledTimes(1)
+    expect(execMock).toHaveBeenCalledWith(
+      'composer',
+      ['config', 'cache-dir', '--working-dir=subdirectory'],
+      expect.objectContaining({
+        silent: true,
+        listeners: {
+          stdout: expect.any(Function)
+        }
+      })
+    )
+  })
 })

--- a/__tests__/utils/getComposerCacheDirSut.test.ts
+++ b/__tests__/utils/getComposerCacheDirSut.test.ts
@@ -14,23 +14,8 @@ describe('getComposerCacheDir using SUT', () => {
       }
     }
 
-    await exec.exec('composer', ['config', 'cache-dir'], composerExecOptions)
+    await exec.exec('composer', ['--global', 'config', 'cache-dir'], composerExecOptions)
 
     expect(await getComposerCacheDir()).toEqual(localComposerCacheDir.trim())
-  })
-
-  test('returns the real Composer cache directory with a working directory', async () => {
-    let localComposerCacheDir = ''
-
-    const composerExecOptions = {
-      silent: true,
-      listeners: {
-        stdout: (data: Buffer) => (localComposerCacheDir += data.toString())
-      }
-    }
-
-    await exec.exec('composer', ['config', 'cache-dir', '--working-dir=subdirectory'], composerExecOptions)
-
-    expect(await getComposerCacheDir('subdirectory')).toEqual(localComposerCacheDir.trim())
   })
 })

--- a/__tests__/utils/getComposerCacheDirSut.test.ts
+++ b/__tests__/utils/getComposerCacheDirSut.test.ts
@@ -18,4 +18,19 @@ describe('getComposerCacheDir using SUT', () => {
 
     expect(await getComposerCacheDir()).toEqual(localComposerCacheDir.trim())
   })
+
+  test('returns the real Composer cache directory with a working directory', async () => {
+    let localComposerCacheDir = ''
+
+    const composerExecOptions = {
+      silent: true,
+      listeners: {
+        stdout: (data: Buffer) => (localComposerCacheDir += data.toString())
+      }
+    }
+
+    await exec.exec('composer', ['config', 'cache-dir', '--working-dir=subdirectory'], composerExecOptions)
+
+    expect(await getComposerCacheDir('subdirectory')).toEqual(localComposerCacheDir.trim())
+  })
 })

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -119510,7 +119510,10 @@ const getOperatingSystem_1 = __nccwpck_require__(7652);
 const getPhpVersion_1 = __nccwpck_require__(4589);
 function getCacheKeys(dependencyVersions = 'locked', composerOptions = '', workingDirectory = '') {
     return __awaiter(this, void 0, void 0, function* () {
-        const composerHash = yield hashFiles_1.hashFiles('composer.json\ncomposer.lock');
+        const composerHash = yield hashFiles_1.hashFiles([
+            `${workingDirectory ? `${workingDirectory}/` : ''}composer.json`,
+            `${workingDirectory ? `${workingDirectory}/` : ''}composer.lock`
+        ].join('\n'));
         const phpVersion = yield getPhpVersion_1.getPhpVersion();
         const keyOs = getOperatingSystem_1.getOperatingSystem();
         const keyWorkingDirectory = workingDirectory ? `-${workingDirectory}` : '';

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -119253,7 +119253,7 @@ function mainAction() {
             const composerOptions = core_1.getInput('composer-options');
             const inputDependencyVersions = core_1.getInput('dependency-versions');
             const workingDirectory = core_1.getInput('working-directory');
-            const composerCacheDir = yield utils.getComposerCacheDir(workingDirectory);
+            const composerCacheDir = yield utils.getComposerCacheDir();
             const cleanedDependencyVersions = utils.getDependencyVersions(inputDependencyVersions);
             const composerCacheKeys = yield utils.getCacheKeys(cleanedDependencyVersions, composerOptions, workingDirectory);
             yield cache.cache(cache.restoreFactory(), [composerCacheDir], composerCacheKeys.key, composerCacheKeys.restoreKeys);
@@ -119549,7 +119549,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getComposerCacheDir = void 0;
 const exec_1 = __nccwpck_require__(1514);
 const core_1 = __nccwpck_require__(2186);
-function getComposerCacheDir(workingDir = '') {
+function getComposerCacheDir() {
     return __awaiter(this, void 0, void 0, function* () {
         let composerCacheDir = '';
         const composerExecOptions = {
@@ -119558,10 +119558,7 @@ function getComposerCacheDir(workingDir = '') {
                 stdout: (data) => (composerCacheDir += data.toString())
             }
         };
-        const args = ['config', 'cache-dir'];
-        if (workingDir !== '')
-            args.push(`--working-dir=${workingDir}`);
-        yield exec_1.exec('composer', args, composerExecOptions);
+        yield exec_1.exec('composer', ['--global', 'config', 'cache-dir'], composerExecOptions);
         composerCacheDir = composerCacheDir.trim();
         core_1.info(`Composer cache directory found at ${composerCacheDir}`);
         return composerCacheDir;

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -3,7 +3,7 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 5241:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -15,8 +15,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__webpack_require__(2087));
-const utils_1 = __webpack_require__(5278);
+const os = __importStar(__nccwpck_require__(2087));
+const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
  *
@@ -89,7 +89,7 @@ function escapeProperty(s) {
 /***/ }),
 
 /***/ 2186:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -110,11 +110,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __webpack_require__(5241);
-const file_command_1 = __webpack_require__(717);
-const utils_1 = __webpack_require__(5278);
-const os = __importStar(__webpack_require__(2087));
-const path = __importStar(__webpack_require__(5622));
+const command_1 = __nccwpck_require__(5241);
+const file_command_1 = __nccwpck_require__(717);
+const utils_1 = __nccwpck_require__(5278);
+const os = __importStar(__nccwpck_require__(2087));
+const path = __importStar(__nccwpck_require__(5622));
 /**
  * The code to exit an action
  */
@@ -334,7 +334,7 @@ exports.getState = getState;
 /***/ }),
 
 /***/ 717:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -349,9 +349,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__webpack_require__(5747));
-const os = __importStar(__webpack_require__(2087));
-const utils_1 = __webpack_require__(5278);
+const fs = __importStar(__nccwpck_require__(5747));
+const os = __importStar(__nccwpck_require__(2087));
+const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -396,7 +396,7 @@ exports.toCommandValue = toCommandValue;
 /***/ }),
 
 /***/ 1514:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -417,7 +417,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__webpack_require__(8159));
+const tr = __importStar(__nccwpck_require__(8159));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -447,7 +447,7 @@ exports.exec = exec;
 /***/ }),
 
 /***/ 8159:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -468,12 +468,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__webpack_require__(2087));
-const events = __importStar(__webpack_require__(8614));
-const child = __importStar(__webpack_require__(3129));
-const path = __importStar(__webpack_require__(5622));
-const io = __importStar(__webpack_require__(7351));
-const ioUtil = __importStar(__webpack_require__(1962));
+const os = __importStar(__nccwpck_require__(2087));
+const events = __importStar(__nccwpck_require__(8614));
+const child = __importStar(__nccwpck_require__(3129));
+const path = __importStar(__nccwpck_require__(5622));
+const io = __importStar(__nccwpck_require__(7351));
+const ioUtil = __importStar(__nccwpck_require__(1962));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1054,7 +1054,7 @@ class ExecState extends events.EventEmitter {
 /***/ }),
 
 /***/ 8090:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1068,7 +1068,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const internal_globber_1 = __webpack_require__(8298);
+const internal_globber_1 = __nccwpck_require__(8298);
 /**
  * Constructs a globber
  *
@@ -1086,7 +1086,7 @@ exports.create = create;
 /***/ }),
 
 /***/ 1026:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1098,7 +1098,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__webpack_require__(2186));
+const core = __importStar(__nccwpck_require__(2186));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -1130,7 +1130,7 @@ exports.getOptions = getOptions;
 /***/ }),
 
 /***/ 8298:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1170,14 +1170,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__webpack_require__(2186));
-const fs = __importStar(__webpack_require__(5747));
-const globOptionsHelper = __importStar(__webpack_require__(1026));
-const path = __importStar(__webpack_require__(5622));
-const patternHelper = __importStar(__webpack_require__(9005));
-const internal_match_kind_1 = __webpack_require__(1063);
-const internal_pattern_1 = __webpack_require__(4536);
-const internal_search_state_1 = __webpack_require__(9117);
+const core = __importStar(__nccwpck_require__(2186));
+const fs = __importStar(__nccwpck_require__(5747));
+const globOptionsHelper = __importStar(__nccwpck_require__(1026));
+const path = __importStar(__nccwpck_require__(5622));
+const patternHelper = __importStar(__nccwpck_require__(9005));
+const internal_match_kind_1 = __nccwpck_require__(1063);
+const internal_pattern_1 = __nccwpck_require__(4536);
+const internal_search_state_1 = __nccwpck_require__(9117);
 const IS_WINDOWS = process.platform === 'win32';
 class DefaultGlobber {
     constructor(options) {
@@ -1383,7 +1383,7 @@ var MatchKind;
 /***/ }),
 
 /***/ 1849:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1398,8 +1398,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path = __importStar(__webpack_require__(5622));
-const assert_1 = __importDefault(__webpack_require__(2357));
+const path = __importStar(__nccwpck_require__(5622));
+const assert_1 = __importDefault(__nccwpck_require__(2357));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Similar to path.dirname except normalizes the path separators and slightly better handling for Windows UNC paths.
@@ -1575,7 +1575,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 /***/ }),
 
 /***/ 6836:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1590,9 +1590,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path = __importStar(__webpack_require__(5622));
-const pathHelper = __importStar(__webpack_require__(1849));
-const assert_1 = __importDefault(__webpack_require__(2357));
+const path = __importStar(__nccwpck_require__(5622));
+const pathHelper = __importStar(__nccwpck_require__(1849));
+const assert_1 = __importDefault(__nccwpck_require__(2357));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Helper class for parsing paths into segments
@@ -1682,7 +1682,7 @@ exports.Path = Path;
 /***/ }),
 
 /***/ 9005:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1694,8 +1694,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const pathHelper = __importStar(__webpack_require__(1849));
-const internal_match_kind_1 = __webpack_require__(1063);
+const pathHelper = __importStar(__nccwpck_require__(1849));
+const internal_match_kind_1 = __nccwpck_require__(1063);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -1770,7 +1770,7 @@ exports.partialMatch = partialMatch;
 /***/ }),
 
 /***/ 4536:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1785,13 +1785,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__webpack_require__(2087));
-const path = __importStar(__webpack_require__(5622));
-const pathHelper = __importStar(__webpack_require__(1849));
-const assert_1 = __importDefault(__webpack_require__(2357));
-const minimatch_1 = __webpack_require__(3973);
-const internal_match_kind_1 = __webpack_require__(1063);
-const internal_path_1 = __webpack_require__(6836);
+const os = __importStar(__nccwpck_require__(2087));
+const path = __importStar(__nccwpck_require__(5622));
+const pathHelper = __importStar(__nccwpck_require__(1849));
+const assert_1 = __importDefault(__nccwpck_require__(2357));
+const minimatch_1 = __nccwpck_require__(3973);
+const internal_match_kind_1 = __nccwpck_require__(1063);
+const internal_path_1 = __nccwpck_require__(6836);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, segments, homedir) {
@@ -2035,7 +2035,7 @@ exports.SearchState = SearchState;
 /***/ }),
 
 /***/ 1962:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -2050,9 +2050,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const assert_1 = __webpack_require__(2357);
-const fs = __webpack_require__(5747);
-const path = __webpack_require__(5622);
+const assert_1 = __nccwpck_require__(2357);
+const fs = __nccwpck_require__(5747);
+const path = __nccwpck_require__(5622);
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
 exports.IS_WINDOWS = process.platform === 'win32';
 function exists(fsPath) {
@@ -2237,7 +2237,7 @@ function isUnixExecutable(stats) {
 /***/ }),
 
 /***/ 7351:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -2251,10 +2251,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const childProcess = __webpack_require__(3129);
-const path = __webpack_require__(5622);
-const util_1 = __webpack_require__(1669);
-const ioUtil = __webpack_require__(1962);
+const childProcess = __nccwpck_require__(3129);
+const path = __nccwpck_require__(5622);
+const util_1 = __nccwpck_require__(1669);
+const ioUtil = __nccwpck_require__(1962);
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2601,10 +2601,10 @@ function range(a, b, str) {
 /***/ }),
 
 /***/ 3717:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __webpack_require__(6891);
-var balanced = __webpack_require__(9417);
+var concatMap = __nccwpck_require__(6891);
+var balanced = __nccwpck_require__(9417);
 
 module.exports = expandTop;
 
@@ -2809,7 +2809,7 @@ function expand(str, isTop) {
 /***/ }),
 
 /***/ 7607:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports =
 /******/ (function(modules, runtime) { // webpackBootstrap
@@ -3984,7 +3984,7 @@ exports.assertDefined = assertDefined;
 /* 16 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4016);
+module.exports = __nccwpck_require__(4016);
 
 /***/ }),
 /* 17 */,
@@ -4527,7 +4527,7 @@ module.exports = v1;
 /* 87 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2087);
+module.exports = __nccwpck_require__(2087);
 
 /***/ }),
 /* 88 */,
@@ -6210,7 +6210,7 @@ exports.saveCache = saveCache;
 /* 129 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(3129);
+module.exports = __nccwpck_require__(3129);
 
 /***/ }),
 /* 130 */,
@@ -7564,14 +7564,14 @@ exports.default = _default;
 /* 211 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(7211);
+module.exports = __nccwpck_require__(7211);
 
 /***/ }),
 /* 212 */,
 /* 213 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4213);
+module.exports = __nccwpck_require__(4213);
 
 /***/ }),
 /* 214 */,
@@ -11640,7 +11640,7 @@ exports.create = create;
 /* 293 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4293);
+module.exports = __nccwpck_require__(4293);
 
 /***/ }),
 /* 294 */,
@@ -11904,7 +11904,7 @@ exports.default = _default;
 /* 304 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4304);
+module.exports = __nccwpck_require__(4304);
 
 /***/ }),
 /* 305 */,
@@ -12604,7 +12604,7 @@ var SamplingDecision;
 /* 343 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8213);
+module.exports = __nccwpck_require__(8213);
 
 /***/ }),
 /* 344 */,
@@ -12769,7 +12769,7 @@ exports.pathMatch = pathMatch;
 /* 357 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2357);
+module.exports = __nccwpck_require__(2357);
 
 /***/ }),
 /* 358 */,
@@ -39646,7 +39646,7 @@ module.exports = __nested_webpack_require_1411606__(141);
 /* 417 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(6417);
+module.exports = __nccwpck_require__(6417);
 
 /***/ }),
 /* 418 */,
@@ -45314,7 +45314,7 @@ exports.getOptions = getOptions;
 /* 605 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8605);
+module.exports = __nccwpck_require__(8605);
 
 /***/ }),
 /* 606 */
@@ -45393,7 +45393,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 614 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8614);
+module.exports = __nccwpck_require__(8614);
 
 /***/ }),
 /* 615 */,
@@ -45499,7 +45499,7 @@ function range(a, b, str) {
 /* 622 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5622);
+module.exports = __nccwpck_require__(5622);
 
 /***/ }),
 /* 623 */,
@@ -45718,7 +45718,7 @@ exports.NOOP_BATCH_OBSERVER_METRIC = new NoopBatchObserverMetric();
 /* 631 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1631);
+module.exports = __nccwpck_require__(1631);
 
 /***/ }),
 /* 632 */,
@@ -47930,7 +47930,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 669 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1669);
+module.exports = __nccwpck_require__(1669);
 
 /***/ }),
 /* 670 */
@@ -49323,7 +49323,7 @@ exports.NOOP_HTTP_TEXT_PROPAGATOR = new NoopHttpTextPropagator();
 /* 747 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5747);
+module.exports = __nccwpck_require__(5747);
 
 /***/ }),
 /* 748 */,
@@ -49690,7 +49690,7 @@ exports.defaultSetter = defaultSetter;
 /* 761 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8761);
+module.exports = __nccwpck_require__(8761);
 
 /***/ }),
 /* 762 */,
@@ -51293,7 +51293,7 @@ FormData.prototype.toString = function () {
 /* 794 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2413);
+module.exports = __nccwpck_require__(2413);
 
 /***/ }),
 /* 795 */,
@@ -52045,7 +52045,7 @@ module.exports = v4;
 /* 835 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8835);
+module.exports = __nccwpck_require__(8835);
 
 /***/ }),
 /* 836 */,
@@ -60527,7 +60527,7 @@ exports.userAgentPolicy = userAgentPolicy;
 /***/ }),
 
 /***/ 8973:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports =
 /******/ (function(modules, runtime) { // webpackBootstrap
@@ -61702,7 +61702,7 @@ exports.assertDefined = assertDefined;
 /* 16 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4016);
+module.exports = __nccwpck_require__(4016);
 
 /***/ }),
 /* 17 */,
@@ -62245,7 +62245,7 @@ module.exports = v1;
 /* 87 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2087);
+module.exports = __nccwpck_require__(2087);
 
 /***/ }),
 /* 88 */,
@@ -63928,7 +63928,7 @@ exports.saveCache = saveCache;
 /* 129 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(3129);
+module.exports = __nccwpck_require__(3129);
 
 /***/ }),
 /* 130 */,
@@ -65282,14 +65282,14 @@ exports.default = _default;
 /* 211 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(7211);
+module.exports = __nccwpck_require__(7211);
 
 /***/ }),
 /* 212 */,
 /* 213 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4213);
+module.exports = __nccwpck_require__(4213);
 
 /***/ }),
 /* 214 */,
@@ -69358,7 +69358,7 @@ exports.create = create;
 /* 293 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4293);
+module.exports = __nccwpck_require__(4293);
 
 /***/ }),
 /* 294 */,
@@ -69622,7 +69622,7 @@ exports.default = _default;
 /* 304 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4304);
+module.exports = __nccwpck_require__(4304);
 
 /***/ }),
 /* 305 */,
@@ -70322,7 +70322,7 @@ var SamplingDecision;
 /* 343 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8213);
+module.exports = __nccwpck_require__(8213);
 
 /***/ }),
 /* 344 */,
@@ -70487,7 +70487,7 @@ exports.pathMatch = pathMatch;
 /* 357 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2357);
+module.exports = __nccwpck_require__(2357);
 
 /***/ }),
 /* 358 */,
@@ -97364,7 +97364,7 @@ module.exports = __nested_webpack_require_1411606__(141);
 /* 417 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(6417);
+module.exports = __nccwpck_require__(6417);
 
 /***/ }),
 /* 418 */,
@@ -103032,7 +103032,7 @@ exports.getOptions = getOptions;
 /* 605 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8605);
+module.exports = __nccwpck_require__(8605);
 
 /***/ }),
 /* 606 */
@@ -103111,7 +103111,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 614 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8614);
+module.exports = __nccwpck_require__(8614);
 
 /***/ }),
 /* 615 */,
@@ -103217,7 +103217,7 @@ function range(a, b, str) {
 /* 622 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5622);
+module.exports = __nccwpck_require__(5622);
 
 /***/ }),
 /* 623 */,
@@ -103436,7 +103436,7 @@ exports.NOOP_BATCH_OBSERVER_METRIC = new NoopBatchObserverMetric();
 /* 631 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1631);
+module.exports = __nccwpck_require__(1631);
 
 /***/ }),
 /* 632 */,
@@ -105648,7 +105648,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 669 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1669);
+module.exports = __nccwpck_require__(1669);
 
 /***/ }),
 /* 670 */
@@ -107131,7 +107131,7 @@ exports.NOOP_HTTP_TEXT_PROPAGATOR = new NoopHttpTextPropagator();
 /* 747 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5747);
+module.exports = __nccwpck_require__(5747);
 
 /***/ }),
 /* 748 */,
@@ -107498,7 +107498,7 @@ exports.defaultSetter = defaultSetter;
 /* 761 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8761);
+module.exports = __nccwpck_require__(8761);
 
 /***/ }),
 /* 762 */,
@@ -109010,7 +109010,7 @@ FormData.prototype.toString = function () {
 /* 794 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2413);
+module.exports = __nccwpck_require__(2413);
 
 /***/ }),
 /* 795 */,
@@ -109762,7 +109762,7 @@ module.exports = v4;
 /* 835 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8835);
+module.exports = __nccwpck_require__(8835);
 
 /***/ }),
 /* 836 */,
@@ -118264,18 +118264,18 @@ var isArray = Array.isArray || function (xs) {
 /***/ }),
 
 /***/ 3973:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
 var path = { sep: '/' }
 try {
-  path = __webpack_require__(5622)
+  path = __nccwpck_require__(5622)
 } catch (er) {}
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __webpack_require__(3717)
+var expand = __nccwpck_require__(3717)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -119194,22 +119194,22 @@ function regExpEscape (s) {
 /***/ }),
 
 /***/ 6535:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.postAction = exports.mainAction = void 0;
-var mainAction_1 = __webpack_require__(1615);
+var mainAction_1 = __nccwpck_require__(1615);
 Object.defineProperty(exports, "mainAction", ({ enumerable: true, get: function () { return mainAction_1.mainAction; } }));
-var postAction_1 = __webpack_require__(2028);
+var postAction_1 = __nccwpck_require__(2028);
 Object.defineProperty(exports, "postAction", ({ enumerable: true, get: function () { return postAction_1.postAction; } }));
 
 
 /***/ }),
 
 /***/ 1615:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119243,17 +119243,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.mainAction = void 0;
-const cache = __importStar(__webpack_require__(1251));
-const composer = __importStar(__webpack_require__(6444));
-const utils = __importStar(__webpack_require__(6252));
-const core_1 = __webpack_require__(2186);
+const cache = __importStar(__nccwpck_require__(1251));
+const composer = __importStar(__nccwpck_require__(6444));
+const utils = __importStar(__nccwpck_require__(6252));
+const core_1 = __nccwpck_require__(2186);
 function mainAction() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const composerOptions = core_1.getInput('composer-options');
             const inputDependencyVersions = core_1.getInput('dependency-versions');
             const workingDirectory = core_1.getInput('working-directory');
-            const composerCacheDir = yield utils.getComposerCacheDir();
+            const composerCacheDir = yield utils.getComposerCacheDir(workingDirectory);
             const cleanedDependencyVersions = utils.getDependencyVersions(inputDependencyVersions);
             const composerCacheKeys = yield utils.getCacheKeys(cleanedDependencyVersions, composerOptions, workingDirectory);
             yield cache.cache(cache.restoreFactory(), [composerCacheDir], composerCacheKeys.key, composerCacheKeys.restoreKeys);
@@ -119270,7 +119270,7 @@ exports.mainAction = mainAction;
 /***/ }),
 
 /***/ 2028:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119304,9 +119304,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.postAction = void 0;
-const cache = __importStar(__webpack_require__(1251));
-const utils = __importStar(__webpack_require__(6252));
-const core_1 = __webpack_require__(2186);
+const cache = __importStar(__nccwpck_require__(1251));
+const utils = __importStar(__nccwpck_require__(6252));
+const core_1 = __nccwpck_require__(2186);
 function postAction() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -119358,7 +119358,7 @@ exports.cache = cache;
 /***/ }),
 
 /***/ 9543:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119376,12 +119376,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveFactory = exports.restoreFactory = void 0;
 /* istanbul ignore next */
 function restoreFactory() {
-    return () => __awaiter(this, void 0, void 0, function* () { return yield __webpack_require__(7607); });
+    return () => __awaiter(this, void 0, void 0, function* () { return yield __nccwpck_require__(7607); });
 }
 exports.restoreFactory = restoreFactory;
 /* istanbul ignore next */
 function saveFactory() {
-    return () => __awaiter(this, void 0, void 0, function* () { return yield __webpack_require__(8973); });
+    return () => __awaiter(this, void 0, void 0, function* () { return yield __nccwpck_require__(8973); });
 }
 exports.saveFactory = saveFactory;
 
@@ -119389,15 +119389,15 @@ exports.saveFactory = saveFactory;
 /***/ }),
 
 /***/ 1251:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveFactory = exports.restoreFactory = exports.cache = void 0;
-var cache_1 = __webpack_require__(1295);
+var cache_1 = __nccwpck_require__(1295);
 Object.defineProperty(exports, "cache", ({ enumerable: true, get: function () { return cache_1.cache; } }));
-var factory_1 = __webpack_require__(9543);
+var factory_1 = __nccwpck_require__(9543);
 Object.defineProperty(exports, "restoreFactory", ({ enumerable: true, get: function () { return factory_1.restoreFactory; } }));
 Object.defineProperty(exports, "saveFactory", ({ enumerable: true, get: function () { return factory_1.saveFactory; } }));
 
@@ -119405,20 +119405,20 @@ Object.defineProperty(exports, "saveFactory", ({ enumerable: true, get: function
 /***/ }),
 
 /***/ 6444:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.install = void 0;
-var install_1 = __webpack_require__(8460);
+var install_1 = __nccwpck_require__(8460);
 Object.defineProperty(exports, "install", ({ enumerable: true, get: function () { return install_1.install; } }));
 
 
 /***/ }),
 
 /***/ 8460:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119433,7 +119433,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.install = void 0;
-const exec_1 = __webpack_require__(1514);
+const exec_1 = __nccwpck_require__(1514);
 function install(dependencyPreference, composerOptions = '', workingDirectory = '') {
     return __awaiter(this, void 0, void 0, function* () {
         const args = [];
@@ -119461,7 +119461,7 @@ exports.install = install;
 /***/ }),
 
 /***/ 399:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119476,7 +119476,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* istanbul ignore next */
-const actions_1 = __webpack_require__(6535);
+const actions_1 = __nccwpck_require__(6535);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         yield actions_1.mainAction();
@@ -119489,7 +119489,7 @@ exports.default = run;
 /***/ }),
 
 /***/ 5196:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119504,10 +119504,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCacheKeys = void 0;
-const hashFiles_1 = __webpack_require__(6997);
-const core_1 = __webpack_require__(2186);
-const getOperatingSystem_1 = __webpack_require__(7652);
-const getPhpVersion_1 = __webpack_require__(4589);
+const hashFiles_1 = __nccwpck_require__(6997);
+const core_1 = __nccwpck_require__(2186);
+const getOperatingSystem_1 = __nccwpck_require__(7652);
+const getPhpVersion_1 = __nccwpck_require__(4589);
 function getCacheKeys(dependencyVersions = 'locked', composerOptions = '', workingDirectory = '') {
     return __awaiter(this, void 0, void 0, function* () {
         const composerHash = yield hashFiles_1.hashFiles('composer.json\ncomposer.lock');
@@ -119532,7 +119532,7 @@ exports.getCacheKeys = getCacheKeys;
 /***/ }),
 
 /***/ 8774:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119547,9 +119547,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getComposerCacheDir = void 0;
-const exec_1 = __webpack_require__(1514);
-const core_1 = __webpack_require__(2186);
-function getComposerCacheDir() {
+const exec_1 = __nccwpck_require__(1514);
+const core_1 = __nccwpck_require__(2186);
+function getComposerCacheDir(workingDir = '') {
     return __awaiter(this, void 0, void 0, function* () {
         let composerCacheDir = '';
         const composerExecOptions = {
@@ -119558,7 +119558,10 @@ function getComposerCacheDir() {
                 stdout: (data) => (composerCacheDir += data.toString())
             }
         };
-        yield exec_1.exec('composer', ['config', 'cache-dir'], composerExecOptions);
+        const args = ['config', 'cache-dir'];
+        if (workingDir !== '')
+            args.push(`--working-dir=${workingDir}`);
+        yield exec_1.exec('composer', args, composerExecOptions);
         composerCacheDir = composerCacheDir.trim();
         core_1.info(`Composer cache directory found at ${composerCacheDir}`);
         return composerCacheDir;
@@ -119570,13 +119573,13 @@ exports.getComposerCacheDir = getComposerCacheDir;
 /***/ }),
 
 /***/ 6582:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDependencyVersions = void 0;
-const core_1 = __webpack_require__(2186);
+const core_1 = __nccwpck_require__(2186);
 function getDependencyVersions(dependencyVersions) {
     let versionsDetermined = 'locked';
     if (dependencyVersions === undefined) {
@@ -119597,13 +119600,13 @@ exports.getDependencyVersions = getDependencyVersions;
 /***/ }),
 
 /***/ 7652:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperatingSystem = void 0;
-const core_1 = __webpack_require__(2186);
+const core_1 = __nccwpck_require__(2186);
 function getOperatingSystem() {
     const os = process.platform;
     core_1.info(`Operating system is ${os}`);
@@ -119615,7 +119618,7 @@ exports.getOperatingSystem = getOperatingSystem;
 /***/ }),
 
 /***/ 4589:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119630,8 +119633,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getPhpVersion = void 0;
-const exec_1 = __webpack_require__(1514);
-const core_1 = __webpack_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
+const core_1 = __nccwpck_require__(2186);
 function getPhpVersion() {
     return __awaiter(this, void 0, void 0, function* () {
         let phpVersion = '';
@@ -119653,7 +119656,7 @@ exports.getPhpVersion = getPhpVersion;
 /***/ }),
 
 /***/ 6997:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119694,12 +119697,12 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashFiles = void 0;
-const glob = __importStar(__webpack_require__(8090));
-const stream = __importStar(__webpack_require__(2413));
-const util = __importStar(__webpack_require__(1669));
-const path = __importStar(__webpack_require__(5622));
-const crypto_1 = __webpack_require__(6417);
-const fs_1 = __webpack_require__(5747);
+const glob = __importStar(__nccwpck_require__(8090));
+const stream = __importStar(__nccwpck_require__(2413));
+const util = __importStar(__nccwpck_require__(1669));
+const path = __importStar(__nccwpck_require__(5622));
+const crypto_1 = __nccwpck_require__(6417);
+const fs_1 = __nccwpck_require__(5747);
 function hashFiles(matchPatterns = '', followSymbolicLinks = false) {
     var e_1, _a;
     return __awaiter(this, void 0, void 0, function* () {
@@ -119745,23 +119748,23 @@ exports.hashFiles = hashFiles;
 /***/ }),
 
 /***/ 6252:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashFiles = exports.getPhpVersion = exports.getOperatingSystem = exports.getDependencyVersions = exports.getComposerCacheDir = exports.getCacheKeys = void 0;
-var getCacheKeys_1 = __webpack_require__(5196);
+var getCacheKeys_1 = __nccwpck_require__(5196);
 Object.defineProperty(exports, "getCacheKeys", ({ enumerable: true, get: function () { return getCacheKeys_1.getCacheKeys; } }));
-var getComposerCacheDir_1 = __webpack_require__(8774);
+var getComposerCacheDir_1 = __nccwpck_require__(8774);
 Object.defineProperty(exports, "getComposerCacheDir", ({ enumerable: true, get: function () { return getComposerCacheDir_1.getComposerCacheDir; } }));
-var getDependencyVersions_1 = __webpack_require__(6582);
+var getDependencyVersions_1 = __nccwpck_require__(6582);
 Object.defineProperty(exports, "getDependencyVersions", ({ enumerable: true, get: function () { return getDependencyVersions_1.getDependencyVersions; } }));
-var getOperatingSystem_1 = __webpack_require__(7652);
+var getOperatingSystem_1 = __nccwpck_require__(7652);
 Object.defineProperty(exports, "getOperatingSystem", ({ enumerable: true, get: function () { return getOperatingSystem_1.getOperatingSystem; } }));
-var getPhpVersion_1 = __webpack_require__(4589);
+var getPhpVersion_1 = __nccwpck_require__(4589);
 Object.defineProperty(exports, "getPhpVersion", ({ enumerable: true, get: function () { return getPhpVersion_1.getPhpVersion; } }));
-var hashFiles_1 = __webpack_require__(6997);
+var hashFiles_1 = __nccwpck_require__(6997);
 Object.defineProperty(exports, "hashFiles", ({ enumerable: true, get: function () { return hashFiles_1.hashFiles; } }));
 
 
@@ -119925,7 +119928,7 @@ module.exports = require("zlib");;
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -119940,7 +119943,7 @@ module.exports = require("zlib");;
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -119953,10 +119956,10 @@ module.exports = require("zlib");;
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(399);
+/******/ 	return __nccwpck_require__(399);
 /******/ })()
 ;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -119510,7 +119510,10 @@ const getOperatingSystem_1 = __nccwpck_require__(7652);
 const getPhpVersion_1 = __nccwpck_require__(4589);
 function getCacheKeys(dependencyVersions = 'locked', composerOptions = '', workingDirectory = '') {
     return __awaiter(this, void 0, void 0, function* () {
-        const composerHash = yield hashFiles_1.hashFiles('composer.json\ncomposer.lock');
+        const composerHash = yield hashFiles_1.hashFiles([
+            `${workingDirectory ? `${workingDirectory}/` : ''}composer.json`,
+            `${workingDirectory ? `${workingDirectory}/` : ''}composer.lock`
+        ].join('\n'));
         const phpVersion = yield getPhpVersion_1.getPhpVersion();
         const keyOs = getOperatingSystem_1.getOperatingSystem();
         const keyWorkingDirectory = workingDirectory ? `-${workingDirectory}` : '';

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -119253,7 +119253,7 @@ function mainAction() {
             const composerOptions = core_1.getInput('composer-options');
             const inputDependencyVersions = core_1.getInput('dependency-versions');
             const workingDirectory = core_1.getInput('working-directory');
-            const composerCacheDir = yield utils.getComposerCacheDir(workingDirectory);
+            const composerCacheDir = yield utils.getComposerCacheDir();
             const cleanedDependencyVersions = utils.getDependencyVersions(inputDependencyVersions);
             const composerCacheKeys = yield utils.getCacheKeys(cleanedDependencyVersions, composerOptions, workingDirectory);
             yield cache.cache(cache.restoreFactory(), [composerCacheDir], composerCacheKeys.key, composerCacheKeys.restoreKeys);
@@ -119549,7 +119549,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getComposerCacheDir = void 0;
 const exec_1 = __nccwpck_require__(1514);
 const core_1 = __nccwpck_require__(2186);
-function getComposerCacheDir(workingDir = '') {
+function getComposerCacheDir() {
     return __awaiter(this, void 0, void 0, function* () {
         let composerCacheDir = '';
         const composerExecOptions = {
@@ -119558,10 +119558,7 @@ function getComposerCacheDir(workingDir = '') {
                 stdout: (data) => (composerCacheDir += data.toString())
             }
         };
-        const args = ['config', 'cache-dir'];
-        if (workingDir !== '')
-            args.push(`--working-dir=${workingDir}`);
-        yield exec_1.exec('composer', args, composerExecOptions);
+        yield exec_1.exec('composer', ['--global', 'config', 'cache-dir'], composerExecOptions);
         composerCacheDir = composerCacheDir.trim();
         core_1.info(`Composer cache directory found at ${composerCacheDir}`);
         return composerCacheDir;

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -3,7 +3,7 @@ module.exports =
 /******/ 	var __webpack_modules__ = ({
 
 /***/ 5241:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -15,8 +15,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__webpack_require__(2087));
-const utils_1 = __webpack_require__(5278);
+const os = __importStar(__nccwpck_require__(2087));
+const utils_1 = __nccwpck_require__(5278);
 /**
  * Commands
  *
@@ -89,7 +89,7 @@ function escapeProperty(s) {
 /***/ }),
 
 /***/ 2186:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -110,11 +110,11 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __webpack_require__(5241);
-const file_command_1 = __webpack_require__(717);
-const utils_1 = __webpack_require__(5278);
-const os = __importStar(__webpack_require__(2087));
-const path = __importStar(__webpack_require__(5622));
+const command_1 = __nccwpck_require__(5241);
+const file_command_1 = __nccwpck_require__(717);
+const utils_1 = __nccwpck_require__(5278);
+const os = __importStar(__nccwpck_require__(2087));
+const path = __importStar(__nccwpck_require__(5622));
 /**
  * The code to exit an action
  */
@@ -334,7 +334,7 @@ exports.getState = getState;
 /***/ }),
 
 /***/ 717:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -349,9 +349,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const fs = __importStar(__webpack_require__(5747));
-const os = __importStar(__webpack_require__(2087));
-const utils_1 = __webpack_require__(5278);
+const fs = __importStar(__nccwpck_require__(5747));
+const os = __importStar(__nccwpck_require__(2087));
+const utils_1 = __nccwpck_require__(5278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -396,7 +396,7 @@ exports.toCommandValue = toCommandValue;
 /***/ }),
 
 /***/ 1514:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -417,7 +417,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__webpack_require__(8159));
+const tr = __importStar(__nccwpck_require__(8159));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -447,7 +447,7 @@ exports.exec = exec;
 /***/ }),
 
 /***/ 8159:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -468,12 +468,12 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__webpack_require__(2087));
-const events = __importStar(__webpack_require__(8614));
-const child = __importStar(__webpack_require__(3129));
-const path = __importStar(__webpack_require__(5622));
-const io = __importStar(__webpack_require__(7351));
-const ioUtil = __importStar(__webpack_require__(1962));
+const os = __importStar(__nccwpck_require__(2087));
+const events = __importStar(__nccwpck_require__(8614));
+const child = __importStar(__nccwpck_require__(3129));
+const path = __importStar(__nccwpck_require__(5622));
+const io = __importStar(__nccwpck_require__(7351));
+const ioUtil = __importStar(__nccwpck_require__(1962));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1054,7 +1054,7 @@ class ExecState extends events.EventEmitter {
 /***/ }),
 
 /***/ 8090:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1068,7 +1068,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const internal_globber_1 = __webpack_require__(8298);
+const internal_globber_1 = __nccwpck_require__(8298);
 /**
  * Constructs a globber
  *
@@ -1086,7 +1086,7 @@ exports.create = create;
 /***/ }),
 
 /***/ 1026:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1098,7 +1098,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__webpack_require__(2186));
+const core = __importStar(__nccwpck_require__(2186));
 /**
  * Returns a copy with defaults filled in.
  */
@@ -1130,7 +1130,7 @@ exports.getOptions = getOptions;
 /***/ }),
 
 /***/ 8298:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1170,14 +1170,14 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__webpack_require__(2186));
-const fs = __importStar(__webpack_require__(5747));
-const globOptionsHelper = __importStar(__webpack_require__(1026));
-const path = __importStar(__webpack_require__(5622));
-const patternHelper = __importStar(__webpack_require__(9005));
-const internal_match_kind_1 = __webpack_require__(1063);
-const internal_pattern_1 = __webpack_require__(4536);
-const internal_search_state_1 = __webpack_require__(9117);
+const core = __importStar(__nccwpck_require__(2186));
+const fs = __importStar(__nccwpck_require__(5747));
+const globOptionsHelper = __importStar(__nccwpck_require__(1026));
+const path = __importStar(__nccwpck_require__(5622));
+const patternHelper = __importStar(__nccwpck_require__(9005));
+const internal_match_kind_1 = __nccwpck_require__(1063);
+const internal_pattern_1 = __nccwpck_require__(4536);
+const internal_search_state_1 = __nccwpck_require__(9117);
 const IS_WINDOWS = process.platform === 'win32';
 class DefaultGlobber {
     constructor(options) {
@@ -1383,7 +1383,7 @@ var MatchKind;
 /***/ }),
 
 /***/ 1849:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1398,8 +1398,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path = __importStar(__webpack_require__(5622));
-const assert_1 = __importDefault(__webpack_require__(2357));
+const path = __importStar(__nccwpck_require__(5622));
+const assert_1 = __importDefault(__nccwpck_require__(2357));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Similar to path.dirname except normalizes the path separators and slightly better handling for Windows UNC paths.
@@ -1575,7 +1575,7 @@ exports.safeTrimTrailingSeparator = safeTrimTrailingSeparator;
 /***/ }),
 
 /***/ 6836:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1590,9 +1590,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const path = __importStar(__webpack_require__(5622));
-const pathHelper = __importStar(__webpack_require__(1849));
-const assert_1 = __importDefault(__webpack_require__(2357));
+const path = __importStar(__nccwpck_require__(5622));
+const pathHelper = __importStar(__nccwpck_require__(1849));
+const assert_1 = __importDefault(__nccwpck_require__(2357));
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Helper class for parsing paths into segments
@@ -1682,7 +1682,7 @@ exports.Path = Path;
 /***/ }),
 
 /***/ 9005:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1694,8 +1694,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const pathHelper = __importStar(__webpack_require__(1849));
-const internal_match_kind_1 = __webpack_require__(1063);
+const pathHelper = __importStar(__nccwpck_require__(1849));
+const internal_match_kind_1 = __nccwpck_require__(1063);
 const IS_WINDOWS = process.platform === 'win32';
 /**
  * Given an array of patterns, returns an array of paths to search.
@@ -1770,7 +1770,7 @@ exports.partialMatch = partialMatch;
 /***/ }),
 
 /***/ 4536:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -1785,13 +1785,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const os = __importStar(__webpack_require__(2087));
-const path = __importStar(__webpack_require__(5622));
-const pathHelper = __importStar(__webpack_require__(1849));
-const assert_1 = __importDefault(__webpack_require__(2357));
-const minimatch_1 = __webpack_require__(3973);
-const internal_match_kind_1 = __webpack_require__(1063);
-const internal_path_1 = __webpack_require__(6836);
+const os = __importStar(__nccwpck_require__(2087));
+const path = __importStar(__nccwpck_require__(5622));
+const pathHelper = __importStar(__nccwpck_require__(1849));
+const assert_1 = __importDefault(__nccwpck_require__(2357));
+const minimatch_1 = __nccwpck_require__(3973);
+const internal_match_kind_1 = __nccwpck_require__(1063);
+const internal_path_1 = __nccwpck_require__(6836);
 const IS_WINDOWS = process.platform === 'win32';
 class Pattern {
     constructor(patternOrNegate, segments, homedir) {
@@ -2035,7 +2035,7 @@ exports.SearchState = SearchState;
 /***/ }),
 
 /***/ 1962:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -2050,9 +2050,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const assert_1 = __webpack_require__(2357);
-const fs = __webpack_require__(5747);
-const path = __webpack_require__(5622);
+const assert_1 = __nccwpck_require__(2357);
+const fs = __nccwpck_require__(5747);
+const path = __nccwpck_require__(5622);
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
 exports.IS_WINDOWS = process.platform === 'win32';
 function exists(fsPath) {
@@ -2237,7 +2237,7 @@ function isUnixExecutable(stats) {
 /***/ }),
 
 /***/ 7351:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -2251,10 +2251,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const childProcess = __webpack_require__(3129);
-const path = __webpack_require__(5622);
-const util_1 = __webpack_require__(1669);
-const ioUtil = __webpack_require__(1962);
+const childProcess = __nccwpck_require__(3129);
+const path = __nccwpck_require__(5622);
+const util_1 = __nccwpck_require__(1669);
+const ioUtil = __nccwpck_require__(1962);
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2601,10 +2601,10 @@ function range(a, b, str) {
 /***/ }),
 
 /***/ 3717:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var concatMap = __webpack_require__(6891);
-var balanced = __webpack_require__(9417);
+var concatMap = __nccwpck_require__(6891);
+var balanced = __nccwpck_require__(9417);
 
 module.exports = expandTop;
 
@@ -2809,7 +2809,7 @@ function expand(str, isTop) {
 /***/ }),
 
 /***/ 7607:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports =
 /******/ (function(modules, runtime) { // webpackBootstrap
@@ -3984,7 +3984,7 @@ exports.assertDefined = assertDefined;
 /* 16 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4016);
+module.exports = __nccwpck_require__(4016);
 
 /***/ }),
 /* 17 */,
@@ -4527,7 +4527,7 @@ module.exports = v1;
 /* 87 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2087);
+module.exports = __nccwpck_require__(2087);
 
 /***/ }),
 /* 88 */,
@@ -6210,7 +6210,7 @@ exports.saveCache = saveCache;
 /* 129 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(3129);
+module.exports = __nccwpck_require__(3129);
 
 /***/ }),
 /* 130 */,
@@ -7564,14 +7564,14 @@ exports.default = _default;
 /* 211 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(7211);
+module.exports = __nccwpck_require__(7211);
 
 /***/ }),
 /* 212 */,
 /* 213 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4213);
+module.exports = __nccwpck_require__(4213);
 
 /***/ }),
 /* 214 */,
@@ -11640,7 +11640,7 @@ exports.create = create;
 /* 293 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4293);
+module.exports = __nccwpck_require__(4293);
 
 /***/ }),
 /* 294 */,
@@ -11904,7 +11904,7 @@ exports.default = _default;
 /* 304 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4304);
+module.exports = __nccwpck_require__(4304);
 
 /***/ }),
 /* 305 */,
@@ -12604,7 +12604,7 @@ var SamplingDecision;
 /* 343 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8213);
+module.exports = __nccwpck_require__(8213);
 
 /***/ }),
 /* 344 */,
@@ -12769,7 +12769,7 @@ exports.pathMatch = pathMatch;
 /* 357 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2357);
+module.exports = __nccwpck_require__(2357);
 
 /***/ }),
 /* 358 */,
@@ -39646,7 +39646,7 @@ module.exports = __nested_webpack_require_1411606__(141);
 /* 417 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(6417);
+module.exports = __nccwpck_require__(6417);
 
 /***/ }),
 /* 418 */,
@@ -45314,7 +45314,7 @@ exports.getOptions = getOptions;
 /* 605 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8605);
+module.exports = __nccwpck_require__(8605);
 
 /***/ }),
 /* 606 */
@@ -45393,7 +45393,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 614 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8614);
+module.exports = __nccwpck_require__(8614);
 
 /***/ }),
 /* 615 */,
@@ -45499,7 +45499,7 @@ function range(a, b, str) {
 /* 622 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5622);
+module.exports = __nccwpck_require__(5622);
 
 /***/ }),
 /* 623 */,
@@ -45718,7 +45718,7 @@ exports.NOOP_BATCH_OBSERVER_METRIC = new NoopBatchObserverMetric();
 /* 631 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1631);
+module.exports = __nccwpck_require__(1631);
 
 /***/ }),
 /* 632 */,
@@ -47930,7 +47930,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 669 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1669);
+module.exports = __nccwpck_require__(1669);
 
 /***/ }),
 /* 670 */
@@ -49323,7 +49323,7 @@ exports.NOOP_HTTP_TEXT_PROPAGATOR = new NoopHttpTextPropagator();
 /* 747 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5747);
+module.exports = __nccwpck_require__(5747);
 
 /***/ }),
 /* 748 */,
@@ -49690,7 +49690,7 @@ exports.defaultSetter = defaultSetter;
 /* 761 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8761);
+module.exports = __nccwpck_require__(8761);
 
 /***/ }),
 /* 762 */,
@@ -51293,7 +51293,7 @@ FormData.prototype.toString = function () {
 /* 794 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2413);
+module.exports = __nccwpck_require__(2413);
 
 /***/ }),
 /* 795 */,
@@ -52045,7 +52045,7 @@ module.exports = v4;
 /* 835 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8835);
+module.exports = __nccwpck_require__(8835);
 
 /***/ }),
 /* 836 */,
@@ -60527,7 +60527,7 @@ exports.userAgentPolicy = userAgentPolicy;
 /***/ }),
 
 /***/ 8973:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports =
 /******/ (function(modules, runtime) { // webpackBootstrap
@@ -61702,7 +61702,7 @@ exports.assertDefined = assertDefined;
 /* 16 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4016);
+module.exports = __nccwpck_require__(4016);
 
 /***/ }),
 /* 17 */,
@@ -62245,7 +62245,7 @@ module.exports = v1;
 /* 87 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2087);
+module.exports = __nccwpck_require__(2087);
 
 /***/ }),
 /* 88 */,
@@ -63928,7 +63928,7 @@ exports.saveCache = saveCache;
 /* 129 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(3129);
+module.exports = __nccwpck_require__(3129);
 
 /***/ }),
 /* 130 */,
@@ -65282,14 +65282,14 @@ exports.default = _default;
 /* 211 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(7211);
+module.exports = __nccwpck_require__(7211);
 
 /***/ }),
 /* 212 */,
 /* 213 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4213);
+module.exports = __nccwpck_require__(4213);
 
 /***/ }),
 /* 214 */,
@@ -69358,7 +69358,7 @@ exports.create = create;
 /* 293 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4293);
+module.exports = __nccwpck_require__(4293);
 
 /***/ }),
 /* 294 */,
@@ -69622,7 +69622,7 @@ exports.default = _default;
 /* 304 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(4304);
+module.exports = __nccwpck_require__(4304);
 
 /***/ }),
 /* 305 */,
@@ -70322,7 +70322,7 @@ var SamplingDecision;
 /* 343 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8213);
+module.exports = __nccwpck_require__(8213);
 
 /***/ }),
 /* 344 */,
@@ -70487,7 +70487,7 @@ exports.pathMatch = pathMatch;
 /* 357 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2357);
+module.exports = __nccwpck_require__(2357);
 
 /***/ }),
 /* 358 */,
@@ -97364,7 +97364,7 @@ module.exports = __nested_webpack_require_1411606__(141);
 /* 417 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(6417);
+module.exports = __nccwpck_require__(6417);
 
 /***/ }),
 /* 418 */,
@@ -103032,7 +103032,7 @@ exports.getOptions = getOptions;
 /* 605 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8605);
+module.exports = __nccwpck_require__(8605);
 
 /***/ }),
 /* 606 */
@@ -103111,7 +103111,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 614 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8614);
+module.exports = __nccwpck_require__(8614);
 
 /***/ }),
 /* 615 */,
@@ -103217,7 +103217,7 @@ function range(a, b, str) {
 /* 622 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5622);
+module.exports = __nccwpck_require__(5622);
 
 /***/ }),
 /* 623 */,
@@ -103436,7 +103436,7 @@ exports.NOOP_BATCH_OBSERVER_METRIC = new NoopBatchObserverMetric();
 /* 631 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1631);
+module.exports = __nccwpck_require__(1631);
 
 /***/ }),
 /* 632 */,
@@ -105648,7 +105648,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 /* 669 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(1669);
+module.exports = __nccwpck_require__(1669);
 
 /***/ }),
 /* 670 */
@@ -107131,7 +107131,7 @@ exports.NOOP_HTTP_TEXT_PROPAGATOR = new NoopHttpTextPropagator();
 /* 747 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(5747);
+module.exports = __nccwpck_require__(5747);
 
 /***/ }),
 /* 748 */,
@@ -107498,7 +107498,7 @@ exports.defaultSetter = defaultSetter;
 /* 761 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8761);
+module.exports = __nccwpck_require__(8761);
 
 /***/ }),
 /* 762 */,
@@ -109010,7 +109010,7 @@ FormData.prototype.toString = function () {
 /* 794 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(2413);
+module.exports = __nccwpck_require__(2413);
 
 /***/ }),
 /* 795 */,
@@ -109762,7 +109762,7 @@ module.exports = v4;
 /* 835 */
 /***/ (function(module) {
 
-module.exports = __webpack_require__(8835);
+module.exports = __nccwpck_require__(8835);
 
 /***/ }),
 /* 836 */,
@@ -118264,18 +118264,18 @@ var isArray = Array.isArray || function (xs) {
 /***/ }),
 
 /***/ 3973:
-/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = minimatch
 minimatch.Minimatch = Minimatch
 
 var path = { sep: '/' }
 try {
-  path = __webpack_require__(5622)
+  path = __nccwpck_require__(5622)
 } catch (er) {}
 
 var GLOBSTAR = minimatch.GLOBSTAR = Minimatch.GLOBSTAR = {}
-var expand = __webpack_require__(3717)
+var expand = __nccwpck_require__(3717)
 
 var plTypes = {
   '!': { open: '(?:(?!(?:', close: '))[^/]*?)'},
@@ -119194,22 +119194,22 @@ function regExpEscape (s) {
 /***/ }),
 
 /***/ 6535:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.postAction = exports.mainAction = void 0;
-var mainAction_1 = __webpack_require__(1615);
+var mainAction_1 = __nccwpck_require__(1615);
 Object.defineProperty(exports, "mainAction", ({ enumerable: true, get: function () { return mainAction_1.mainAction; } }));
-var postAction_1 = __webpack_require__(2028);
+var postAction_1 = __nccwpck_require__(2028);
 Object.defineProperty(exports, "postAction", ({ enumerable: true, get: function () { return postAction_1.postAction; } }));
 
 
 /***/ }),
 
 /***/ 1615:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119243,17 +119243,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.mainAction = void 0;
-const cache = __importStar(__webpack_require__(1251));
-const composer = __importStar(__webpack_require__(6444));
-const utils = __importStar(__webpack_require__(6252));
-const core_1 = __webpack_require__(2186);
+const cache = __importStar(__nccwpck_require__(1251));
+const composer = __importStar(__nccwpck_require__(6444));
+const utils = __importStar(__nccwpck_require__(6252));
+const core_1 = __nccwpck_require__(2186);
 function mainAction() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const composerOptions = core_1.getInput('composer-options');
             const inputDependencyVersions = core_1.getInput('dependency-versions');
             const workingDirectory = core_1.getInput('working-directory');
-            const composerCacheDir = yield utils.getComposerCacheDir();
+            const composerCacheDir = yield utils.getComposerCacheDir(workingDirectory);
             const cleanedDependencyVersions = utils.getDependencyVersions(inputDependencyVersions);
             const composerCacheKeys = yield utils.getCacheKeys(cleanedDependencyVersions, composerOptions, workingDirectory);
             yield cache.cache(cache.restoreFactory(), [composerCacheDir], composerCacheKeys.key, composerCacheKeys.restoreKeys);
@@ -119270,7 +119270,7 @@ exports.mainAction = mainAction;
 /***/ }),
 
 /***/ 2028:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119304,9 +119304,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.postAction = void 0;
-const cache = __importStar(__webpack_require__(1251));
-const utils = __importStar(__webpack_require__(6252));
-const core_1 = __webpack_require__(2186);
+const cache = __importStar(__nccwpck_require__(1251));
+const utils = __importStar(__nccwpck_require__(6252));
+const core_1 = __nccwpck_require__(2186);
 function postAction() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -119358,7 +119358,7 @@ exports.cache = cache;
 /***/ }),
 
 /***/ 9543:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119376,12 +119376,12 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveFactory = exports.restoreFactory = void 0;
 /* istanbul ignore next */
 function restoreFactory() {
-    return () => __awaiter(this, void 0, void 0, function* () { return yield __webpack_require__(7607); });
+    return () => __awaiter(this, void 0, void 0, function* () { return yield __nccwpck_require__(7607); });
 }
 exports.restoreFactory = restoreFactory;
 /* istanbul ignore next */
 function saveFactory() {
-    return () => __awaiter(this, void 0, void 0, function* () { return yield __webpack_require__(8973); });
+    return () => __awaiter(this, void 0, void 0, function* () { return yield __nccwpck_require__(8973); });
 }
 exports.saveFactory = saveFactory;
 
@@ -119389,15 +119389,15 @@ exports.saveFactory = saveFactory;
 /***/ }),
 
 /***/ 1251:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.saveFactory = exports.restoreFactory = exports.cache = void 0;
-var cache_1 = __webpack_require__(1295);
+var cache_1 = __nccwpck_require__(1295);
 Object.defineProperty(exports, "cache", ({ enumerable: true, get: function () { return cache_1.cache; } }));
-var factory_1 = __webpack_require__(9543);
+var factory_1 = __nccwpck_require__(9543);
 Object.defineProperty(exports, "restoreFactory", ({ enumerable: true, get: function () { return factory_1.restoreFactory; } }));
 Object.defineProperty(exports, "saveFactory", ({ enumerable: true, get: function () { return factory_1.saveFactory; } }));
 
@@ -119405,20 +119405,20 @@ Object.defineProperty(exports, "saveFactory", ({ enumerable: true, get: function
 /***/ }),
 
 /***/ 6444:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.install = void 0;
-var install_1 = __webpack_require__(8460);
+var install_1 = __nccwpck_require__(8460);
 Object.defineProperty(exports, "install", ({ enumerable: true, get: function () { return install_1.install; } }));
 
 
 /***/ }),
 
 /***/ 8460:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119433,7 +119433,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.install = void 0;
-const exec_1 = __webpack_require__(1514);
+const exec_1 = __nccwpck_require__(1514);
 function install(dependencyPreference, composerOptions = '', workingDirectory = '') {
     return __awaiter(this, void 0, void 0, function* () {
         const args = [];
@@ -119461,7 +119461,7 @@ exports.install = install;
 /***/ }),
 
 /***/ 7051:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119476,7 +119476,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* istanbul ignore next */
-const actions_1 = __webpack_require__(6535);
+const actions_1 = __nccwpck_require__(6535);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         yield actions_1.postAction();
@@ -119489,7 +119489,7 @@ exports.default = run;
 /***/ }),
 
 /***/ 5196:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119504,10 +119504,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getCacheKeys = void 0;
-const hashFiles_1 = __webpack_require__(6997);
-const core_1 = __webpack_require__(2186);
-const getOperatingSystem_1 = __webpack_require__(7652);
-const getPhpVersion_1 = __webpack_require__(4589);
+const hashFiles_1 = __nccwpck_require__(6997);
+const core_1 = __nccwpck_require__(2186);
+const getOperatingSystem_1 = __nccwpck_require__(7652);
+const getPhpVersion_1 = __nccwpck_require__(4589);
 function getCacheKeys(dependencyVersions = 'locked', composerOptions = '', workingDirectory = '') {
     return __awaiter(this, void 0, void 0, function* () {
         const composerHash = yield hashFiles_1.hashFiles('composer.json\ncomposer.lock');
@@ -119532,7 +119532,7 @@ exports.getCacheKeys = getCacheKeys;
 /***/ }),
 
 /***/ 8774:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119547,9 +119547,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getComposerCacheDir = void 0;
-const exec_1 = __webpack_require__(1514);
-const core_1 = __webpack_require__(2186);
-function getComposerCacheDir() {
+const exec_1 = __nccwpck_require__(1514);
+const core_1 = __nccwpck_require__(2186);
+function getComposerCacheDir(workingDir = '') {
     return __awaiter(this, void 0, void 0, function* () {
         let composerCacheDir = '';
         const composerExecOptions = {
@@ -119558,7 +119558,10 @@ function getComposerCacheDir() {
                 stdout: (data) => (composerCacheDir += data.toString())
             }
         };
-        yield exec_1.exec('composer', ['config', 'cache-dir'], composerExecOptions);
+        const args = ['config', 'cache-dir'];
+        if (workingDir !== '')
+            args.push(`--working-dir=${workingDir}`);
+        yield exec_1.exec('composer', args, composerExecOptions);
         composerCacheDir = composerCacheDir.trim();
         core_1.info(`Composer cache directory found at ${composerCacheDir}`);
         return composerCacheDir;
@@ -119570,13 +119573,13 @@ exports.getComposerCacheDir = getComposerCacheDir;
 /***/ }),
 
 /***/ 6582:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getDependencyVersions = void 0;
-const core_1 = __webpack_require__(2186);
+const core_1 = __nccwpck_require__(2186);
 function getDependencyVersions(dependencyVersions) {
     let versionsDetermined = 'locked';
     if (dependencyVersions === undefined) {
@@ -119597,13 +119600,13 @@ exports.getDependencyVersions = getDependencyVersions;
 /***/ }),
 
 /***/ 7652:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getOperatingSystem = void 0;
-const core_1 = __webpack_require__(2186);
+const core_1 = __nccwpck_require__(2186);
 function getOperatingSystem() {
     const os = process.platform;
     core_1.info(`Operating system is ${os}`);
@@ -119615,7 +119618,7 @@ exports.getOperatingSystem = getOperatingSystem;
 /***/ }),
 
 /***/ 4589:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119630,8 +119633,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getPhpVersion = void 0;
-const exec_1 = __webpack_require__(1514);
-const core_1 = __webpack_require__(2186);
+const exec_1 = __nccwpck_require__(1514);
+const core_1 = __nccwpck_require__(2186);
 function getPhpVersion() {
     return __awaiter(this, void 0, void 0, function* () {
         let phpVersion = '';
@@ -119653,7 +119656,7 @@ exports.getPhpVersion = getPhpVersion;
 /***/ }),
 
 /***/ 6997:
-/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
@@ -119694,12 +119697,12 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashFiles = void 0;
-const glob = __importStar(__webpack_require__(8090));
-const stream = __importStar(__webpack_require__(2413));
-const util = __importStar(__webpack_require__(1669));
-const path = __importStar(__webpack_require__(5622));
-const crypto_1 = __webpack_require__(6417);
-const fs_1 = __webpack_require__(5747);
+const glob = __importStar(__nccwpck_require__(8090));
+const stream = __importStar(__nccwpck_require__(2413));
+const util = __importStar(__nccwpck_require__(1669));
+const path = __importStar(__nccwpck_require__(5622));
+const crypto_1 = __nccwpck_require__(6417);
+const fs_1 = __nccwpck_require__(5747);
 function hashFiles(matchPatterns = '', followSymbolicLinks = false) {
     var e_1, _a;
     return __awaiter(this, void 0, void 0, function* () {
@@ -119745,23 +119748,23 @@ exports.hashFiles = hashFiles;
 /***/ }),
 
 /***/ 6252:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.hashFiles = exports.getPhpVersion = exports.getOperatingSystem = exports.getDependencyVersions = exports.getComposerCacheDir = exports.getCacheKeys = void 0;
-var getCacheKeys_1 = __webpack_require__(5196);
+var getCacheKeys_1 = __nccwpck_require__(5196);
 Object.defineProperty(exports, "getCacheKeys", ({ enumerable: true, get: function () { return getCacheKeys_1.getCacheKeys; } }));
-var getComposerCacheDir_1 = __webpack_require__(8774);
+var getComposerCacheDir_1 = __nccwpck_require__(8774);
 Object.defineProperty(exports, "getComposerCacheDir", ({ enumerable: true, get: function () { return getComposerCacheDir_1.getComposerCacheDir; } }));
-var getDependencyVersions_1 = __webpack_require__(6582);
+var getDependencyVersions_1 = __nccwpck_require__(6582);
 Object.defineProperty(exports, "getDependencyVersions", ({ enumerable: true, get: function () { return getDependencyVersions_1.getDependencyVersions; } }));
-var getOperatingSystem_1 = __webpack_require__(7652);
+var getOperatingSystem_1 = __nccwpck_require__(7652);
 Object.defineProperty(exports, "getOperatingSystem", ({ enumerable: true, get: function () { return getOperatingSystem_1.getOperatingSystem; } }));
-var getPhpVersion_1 = __webpack_require__(4589);
+var getPhpVersion_1 = __nccwpck_require__(4589);
 Object.defineProperty(exports, "getPhpVersion", ({ enumerable: true, get: function () { return getPhpVersion_1.getPhpVersion; } }));
-var hashFiles_1 = __webpack_require__(6997);
+var hashFiles_1 = __nccwpck_require__(6997);
 Object.defineProperty(exports, "hashFiles", ({ enumerable: true, get: function () { return hashFiles_1.hashFiles; } }));
 
 
@@ -119925,7 +119928,7 @@ module.exports = require("zlib");;
 /******/ 	var __webpack_module_cache__ = {};
 /******/ 	
 /******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+/******/ 	function __nccwpck_require__(moduleId) {
 /******/ 		// Check if module is in cache
 /******/ 		if(__webpack_module_cache__[moduleId]) {
 /******/ 			return __webpack_module_cache__[moduleId].exports;
@@ -119940,7 +119943,7 @@ module.exports = require("zlib");;
 /******/ 		// Execute the module function
 /******/ 		var threw = true;
 /******/ 		try {
-/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			__webpack_modules__[moduleId].call(module.exports, module, module.exports, __nccwpck_require__);
 /******/ 			threw = false;
 /******/ 		} finally {
 /******/ 			if(threw) delete __webpack_module_cache__[moduleId];
@@ -119953,10 +119956,10 @@ module.exports = require("zlib");;
 /************************************************************************/
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
-/******/ 	__webpack_require__.ab = __dirname + "/";/************************************************************************/
+/******/ 	__nccwpck_require__.ab = __dirname + "/";/************************************************************************/
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(7051);
+/******/ 	return __nccwpck_require__(7051);
 /******/ })()
 ;

--- a/src/actions/mainAction.ts
+++ b/src/actions/mainAction.ts
@@ -9,7 +9,7 @@ export async function mainAction(): Promise<void> {
     const inputDependencyVersions = getInput('dependency-versions')
     const workingDirectory = getInput('working-directory')
 
-    const composerCacheDir = await utils.getComposerCacheDir(workingDirectory)
+    const composerCacheDir = await utils.getComposerCacheDir()
     const cleanedDependencyVersions = utils.getDependencyVersions(
       inputDependencyVersions
     )

--- a/src/actions/mainAction.ts
+++ b/src/actions/mainAction.ts
@@ -9,7 +9,7 @@ export async function mainAction(): Promise<void> {
     const inputDependencyVersions = getInput('dependency-versions')
     const workingDirectory = getInput('working-directory')
 
-    const composerCacheDir = await utils.getComposerCacheDir()
+    const composerCacheDir = await utils.getComposerCacheDir(workingDirectory)
     const cleanedDependencyVersions = utils.getDependencyVersions(
       inputDependencyVersions
     )

--- a/src/utils/getCacheKeys.ts
+++ b/src/utils/getCacheKeys.ts
@@ -11,7 +11,12 @@ export async function getCacheKeys(
   key: string
   restoreKeys: string[]
 }> {
-  const composerHash = await hashFiles('composer.json\ncomposer.lock')
+  const composerHash = await hashFiles(
+    [
+      `${workingDirectory ? `${workingDirectory}/` : ''}composer.json`,
+      `${workingDirectory ? `${workingDirectory}/` : ''}composer.lock`
+    ].join('\n')
+  )
   const phpVersion = await getPhpVersion()
   const keyOs = getOperatingSystem()
   const keyWorkingDirectory = workingDirectory ? `-${workingDirectory}` : ''

--- a/src/utils/getComposerCacheDir.ts
+++ b/src/utils/getComposerCacheDir.ts
@@ -1,7 +1,7 @@
 import {exec} from '@actions/exec'
 import {info} from '@actions/core'
 
-export async function getComposerCacheDir(): Promise<string> {
+export async function getComposerCacheDir(workingDir = ''): Promise<string> {
   let composerCacheDir = ''
   const composerExecOptions = {
     silent: true,
@@ -10,7 +10,10 @@ export async function getComposerCacheDir(): Promise<string> {
     }
   }
 
-  await exec('composer', ['config', 'cache-dir'], composerExecOptions)
+  const args = ['config', 'cache-dir']
+  if (workingDir !== '') args.push(`--working-dir=${workingDir}`)
+
+  await exec('composer', args, composerExecOptions)
 
   composerCacheDir = composerCacheDir.trim()
   info(`Composer cache directory found at ${composerCacheDir}`)

--- a/src/utils/getComposerCacheDir.ts
+++ b/src/utils/getComposerCacheDir.ts
@@ -1,7 +1,7 @@
 import {exec} from '@actions/exec'
 import {info} from '@actions/core'
 
-export async function getComposerCacheDir(workingDir = ''): Promise<string> {
+export async function getComposerCacheDir(): Promise<string> {
   let composerCacheDir = ''
   const composerExecOptions = {
     silent: true,
@@ -10,10 +10,11 @@ export async function getComposerCacheDir(workingDir = ''): Promise<string> {
     }
   }
 
-  const args = ['config', 'cache-dir']
-  if (workingDir !== '') args.push(`--working-dir=${workingDir}`)
-
-  await exec('composer', args, composerExecOptions)
+  await exec(
+    'composer',
+    ['--global', 'config', 'cache-dir'],
+    composerExecOptions
+  )
 
   composerCacheDir = composerCacheDir.trim()
   info(`Composer cache directory found at ${composerCacheDir}`)


### PR DESCRIPTION
Following of #58, #93 and maybe of https://github.com/ramsey/composer-install/issues/58#issuecomment-791889189. 

I totally forgot to use working-directory to get composer cache dir. 
Composer needs a `composer.json` in the working directory to works, otherwise it fails:
![image](https://user-images.githubusercontent.com/2103975/110443440-3537fa00-80bc-11eb-9c9c-9cee7c13d965.png)

Ping @ramsey 

Thanks!

**EDIT:** see 2nd part of https://github.com/ramsey/composer-install/pull/104#issuecomment-794244901