### PR TITLE
Bug fix: don't error out on out-of-sync lock file

### DIFF
--- a/bin/composer_paths.sh
+++ b/bin/composer_paths.sh
@@ -12,6 +12,7 @@ function validate_composer {
     "${php_path}" "${composer_path}" \
         validate \
         --no-check-publish \
+        --no-check-lock \
         --working-dir "${working_directory}" \
         > /dev/null 2>&1
 }

--- a/tests/expect/composer_paths_08.exp
+++ b/tests/expect/composer_paths_08.exp
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S expect -f
+
+set timeout 3
+spawn ../../bin/composer_paths.sh "" "../fixtures/out-of-sync-lock"
+match_max 100000
+
+expect "::debug::Composer path is '*'\r
+::debug::Composer version *\r
+::debug::Composer cache directory found at '*'\r
+::debug::File composer.json found at '../fixtures/out-of-sync-lock/composer.json'\r
+::debug::File composer.lock path computed as '../fixtures/out-of-sync-lock/composer.lock'\r
+::set-output name=command::*\r
+::set-output name=cache-dir::*\r
+::set-output name=json::../fixtures/out-of-sync-lock/composer.json\r
+::set-output name=lock::../fixtures/out-of-sync-lock/composer.lock\r
+"
+expect eof

--- a/tests/fixtures/out-of-sync-lock/composer.json
+++ b/tests/fixtures/out-of-sync-lock/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "ramsey/composer-install-test-out-of-sync-lock",
+    "description": "Tests composer-install when composer.lock file is out of sync.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Ben Ramsey",
+            "email": "ben@benramsey.com"
+        }
+    ],
+    "config": {
+        "platform": {
+
+        }
+    }
+}

--- a/tests/fixtures/out-of-sync-lock/composer.lock
+++ b/tests/fixtures/out-of-sync-lock/composer.lock
@@ -1,0 +1,21 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "32d8479198ae031d96dd19b4332b8b0a",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.40"
+    },
+    "plugin-api-version": "2.2.0"
+}


### PR DESCRIPTION
## Description
As far as I can see, the `--no-check-lock` argument has been available since Composer 1.0, so adding this argument to the `composer validate` command should be safe and should prevent the issues as reported in #206.

Includes tests (though the test isn't running properly yet).

## Motivation and context
Fixes #206

## How has this been tested?
I've tested this locally with the plain command with both Composer 1 and 2, but have not tested this in the context of this action.

I've added a unit test, but haven't managed to get it running properly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
