### PR TITLE
Do not append always empty restore_key

### DIFF
--- a/bin/cache_key.sh
+++ b/bin/cache_key.sh
@@ -39,7 +39,7 @@ else
         "${working_directory}"
     )
 
-    restore_key=("$(join_by - ${key[@]/#/})-" "${restore_key[@]}")
+    restore_key=("$(join_by - ${key[@]/#/})-")
 
     key+=("${files_hash}")
 fi


### PR DESCRIPTION
## Description
It was just initialized: `restore_key=()`

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
