### PR TITLE
ci: convert to single line for code coverage reporting

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -80,6 +80,8 @@ jobs:
         run: "bashcov --root ./bin -- ./tests/bash-test.sh tests/tests.sh"
       - name: "Publish coverage report to Codecov"
         uses: "codecov/codecov-action@v2"
+        with:
+          directory: "./coverage/"
 
   run:
     needs: test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -81,7 +81,7 @@ jobs:
       - name: "Publish coverage report to Codecov"
         uses: "codecov/codecov-action@v2"
         with:
-          directory: "./coverage/"
+          files: "./bin/coverage/codecov-result.json"
 
   run:
     needs: test

--- a/bin/cache_key.sh
+++ b/bin/cache_key.sh
@@ -29,15 +29,7 @@ esac
 if [ -n "${custom_cache_key}" ]; then
     key+=("${custom_cache_key}")
 else
-    key+=(
-        "${runner_os}"
-        "php"
-        "${php_version}"
-        "composer"
-        "${composer_options}"
-        "${dependency_versions}"
-        "${working_directory}"
-    )
+    key+=("${runner_os}" "php" "${php_version}" "composer" "${composer_options}" "${dependency_versions}" "${working_directory}")
 
     restore_key=("$(join_by - ${key[@]/#/})-")
 

--- a/bin/composer_install.sh
+++ b/bin/composer_install.sh
@@ -7,11 +7,7 @@ php_path="${4:-$(which php)}"
 composer_path="${5:-$(which composer)}"
 
 composer_command="update"
-composer_options=(
-    "--no-interaction"
-    "--no-progress"
-    "--ansi"
-)
+composer_options=("--no-interaction" "--no-progress" "--ansi")
 
 case "${dependency_versions}" in
     highest) ;;

--- a/bin/composer_paths.sh
+++ b/bin/composer_paths.sh
@@ -9,12 +9,7 @@ function test_composer {
 }
 
 function validate_composer {
-    "${php_path}" "${composer_path}" \
-        validate \
-        --no-check-publish \
-        --no-check-lock \
-        --working-dir "${working_directory}" \
-        > /dev/null 2>&1
+    "${php_path}" "${composer_path}" validate --no-check-publish --no-check-lock --working-dir "${working_directory}" > /dev/null 2>&1
 }
 
 if ! test_composer; then


### PR DESCRIPTION
Convert multiline arrays and commands in Bash to single lines, in order to fix code coverage issues.