### PR TITLE
GH Actions: re-work the integration tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -217,3 +217,38 @@ jobs:
           working-directory: "${{ matrix.working-directory }}"
           dependency-versions: "${{ matrix.dependency-versions }}"
           custom-cache-key: 'my-super-custom-cache-key'
+
+  run-no-cleanup:
+    needs: test
+    name: "Run unclean"
+    runs-on: "${{ matrix.operating-system }}"
+    strategy:
+      matrix:
+        operating-system:
+          - "ubuntu-latest"
+          - "windows-latest"
+        composer-version:
+          - "v1"
+          - "v2"
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@v2"
+      - name: "Set up PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "latest"
+          tools: "composer:${{ matrix.composer-version }}"
+          coverage: "none"
+
+      - name: "Test: plain install"
+        uses: ./
+
+      - name: "Test: switch to lowest dependencies"
+        uses: ./
+        with:
+          dependency-versions: 'lowest'
+
+      - name: "Test: switch to highest dependencies"
+        uses: ./
+        with:
+          dependency-versions: 'highest'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -108,17 +108,8 @@ jobs:
         composer-version:
           - "v1"
           - "v2"
-        composer-options:
-          - "--ignore-platform-reqs"
-          - ""
         working-directory:
           - "tests/fixtures/with-lock-file"
-          - ""
-        ignore-cache:
-          - "yes"
-          - ""
-        custom-cache-key:
-          - "my-super-custom-cache-key"
           - ""
     steps:
       - name: "Checkout repository"
@@ -129,11 +120,98 @@ jobs:
           php-version: "latest"
           tools: "composer:${{ matrix.composer-version }}"
           coverage: "none"
-      - name: "Run composer-install action"
+
+      - name: "Test: plain install"
         uses: ./
         with:
-          dependency-versions: "${{ matrix.dependency-versions }}"
-          composer-options: "${{ matrix.composer-options }}"
           working-directory: "${{ matrix.working-directory }}"
-          ignore-cache: "${{ matrix.ignore-cache }}"
-          custom-cache-key: "${{ matrix.custom-cache-key }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: ignore platform reqs"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          composer-options: '--ignore-platform-reqs'
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: ignore platform reqs, ignore cache"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          composer-options: '--ignore-platform-reqs'
+          ignore-cache: 'yes'
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: ignore platform reqs, custom cache key"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          composer-options: '--ignore-platform-reqs'
+          custom-cache-key: 'my-super-custom-cache-key'
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: ignore platform reqs, ignore cache, custom cache key"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          composer-options: '--ignore-platform-reqs'
+          ignore-cache: 'yes'
+          custom-cache-key: 'my-super-custom-cache-key'
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: ignore cache"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          ignore-cache: 'yes'
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: ignore cache, custom cache key"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          ignore-cache: 'yes'
+          custom-cache-key: 'my-super-custom-cache-key'
+
+      - name: Clean up between tests
+        run: |
+          git clean -ffdx && git reset --hard HEAD
+          composer clear-cache
+
+      - name: "Test: custom cache key"
+        uses: ./
+        with:
+          working-directory: "${{ matrix.working-directory }}"
+          dependency-versions: "${{ matrix.dependency-versions }}"
+          custom-cache-key: 'my-super-custom-cache-key'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -242,13 +242,17 @@ jobs:
 
       - name: "Test: plain install"
         uses: ./
+        with:
+          working-directory: 'tests/fixtures/with-lock-file'
 
       - name: "Test: switch to lowest dependencies"
         uses: ./
         with:
+          working-directory: 'tests/fixtures/with-lock-file'
           dependency-versions: 'lowest'
 
       - name: "Test: switch to highest dependencies"
         uses: ./
         with:
+          working-directory: 'tests/fixtures/with-lock-file'
           dependency-versions: 'highest'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -110,6 +110,8 @@ jobs:
           - "v2"
         working-directory:
           - "tests/fixtures/with-lock-file"
+          - "tests/fixtures/no-lock-file"
+          - "tests/fixtures/out-of-sync-lock"
           - ""
     steps:
       - name: "Checkout repository"

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
             "email": "ben@benramsey.com"
         }
     ],
-    "require": {
-        "ehime/hello-world": "1.0.5"
+    "require-dev": {
+        "ehime/hello-world": "^1.0.0"
     },
     "config": {
         "allow-plugins": false

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07afce4d403282b01344497e2b8ba6a9",
-    "packages": [
+    "content-hash": "52abd0fd24f907ced897a9e6adeab5bf",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "ehime/hello-world",
             "version": "1.0.5",
@@ -56,7 +57,6 @@
             "time": "2015-07-31T17:53:36+00:00"
         }
     ],
-    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/tests/expect/composer.json
+++ b/tests/expect/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ehime/hello-world": "1.0.5"
+        "ehime/hello-world": "^1.0.0"
     },
     "config": {
         "allow-plugins": false

--- a/tests/expect/composer.lock
+++ b/tests/expect/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e037e746895f35129420cbf41acc8908",
+    "content-hash": "6da8813786f5c3143608266fa0cf0a17",
     "packages": [
         {
             "name": "ehime/hello-world",

--- a/tests/fixtures/no-lock-file/composer.json
+++ b/tests/fixtures/no-lock-file/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ehime/hello-world": "1.0.5"
+        "ehime/hello-world": "^1.0.0"
     },
     "config": {
         "allow-plugins": false

--- a/tests/fixtures/with-lock-file/composer.json
+++ b/tests/fixtures/with-lock-file/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ehime/hello-world": "1.0.5"
+        "ehime/hello-world": "^1.0.0"
     },
     "config": {
         "allow-plugins": false

--- a/tests/fixtures/with-lock-file/composer.lock
+++ b/tests/fixtures/with-lock-file/composer.lock
@@ -4,28 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa5dffd9f21d5d44ce358b01b329e78b",
+    "content-hash": "091919c4ac368d87445398fc8c8c2696",
     "packages": [
         {
             "name": "ehime/hello-world",
-            "version": "1.0.5",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ehime/hello-world.git",
-                "reference": "b1c8cdd2c11272d8c5deec7816e51fa5374217c1"
+                "reference": "033c81f43e6768e817219ab71c6073e6d5b8b094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ehime/hello-world/zipball/b1c8cdd2c11272d8c5deec7816e51fa5374217c1",
-                "reference": "b1c8cdd2c11272d8c5deec7816e51fa5374217c1",
+                "url": "https://api.github.com/repos/ehime/hello-world/zipball/033c81f43e6768e817219ab71c6073e6d5b8b094",
+                "reference": "033c81f43e6768e817219ab71c6073e6d5b8b094",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "0.8.*",
-                "phpunit/phpunit": "4.3.5"
+                "php": ">=5.3.0"
             },
             "type": "library",
             "autoload": {
@@ -34,26 +30,18 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
             "authors": [
                 {
                     "name": "Jd Daniel",
                     "email": "dodomeki@gmail.com"
                 }
             ],
-            "description": "Sample Composer project",
-            "keywords": [
-                "helloworld",
-                "sample",
-                "test"
-            ],
+            "description": "My first Composer project",
             "support": {
                 "issues": "https://github.com/ehime/hello-world/issues",
-                "source": "https://github.com/ehime/hello-world/tree/1.0.5"
+                "source": "https://github.com/ehime/hello-world/tree/1.0.3"
             },
-            "time": "2015-07-31T17:53:36+00:00"
+            "time": "2015-07-31T17:46:00+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
## Description

### GH Actions: re-work the integration tests

This removes three keys from the integration test matrix in favour of adding steps for each of those options to the job.

* The GitHub workspace is cleaned up between each run.
* The Composer cache is removed between each run.

This means that, in effect, the tests are being run in the same way as previously (clean install), but sequentially in one job instead of in parallel in different builds.

This slims down the number of builds per run from 197 to 29.

### GH Actions: run integration tests for additional situations

This adds the `tests/fixtures/no-lock-file` and `tests/fixtures/out-of-sync-lock` working directories to the matrix for the integration tests to test these situations more thoroughly on each commit as well.

Fixes #219

(Number of builds per run are now 53)

### GH Actions: add extra job for unclean install test

Add a job which tests "unclean" installs, i.e. running the action when there is already a `vendor` directory and a Composer `downloads` directory in place.

(Number of builds per run are now 57)

### 🆕 Composer: require-dev the package used for testing

.. in the root `composer.json`.

### 🆕 Tests: update version constraints in test fixtures

... to allow for installing a wider range of versions of the `ehime/hello-world` package.

Includes locking the version for the `with-lock-file` test to `1.0.3` so there are higher and lower versions to switch to during the tests and switching the "unclean" test to use that fixture as a base.

## Motivation and context

See the discussion in #219

## How has this been tested?

By running the action and doing a visual check that the output of various steps match the expected output.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
