### PR TITLE
GH Actions: version update for various predefined actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -36,7 +36,7 @@ jobs:
           - "v2"
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install expect"
         run: |
           sudo apt-get update
@@ -57,7 +57,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Install expect"
         run: |
           sudo apt-get update
@@ -88,7 +88,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Run shellcheck"
         run: "shellcheck --exclude=SC2230 bin/*.sh tests/*.sh"
 
@@ -115,7 +115,7 @@ jobs:
           - ""
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@v2"
         with:
@@ -232,7 +232,7 @@ jobs:
           - "v2"
     steps:
       - name: "Checkout repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@v2"
         with:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ strategy:
         composer-options: "--ignore-platform-reqs"
 
 steps:
-  - uses: "actions/checkout@v2"
+  - uses: "actions/checkout@v3"
   - uses: "shivammathur/setup-php@v2"
     with:
       php-version: "${{ matrix.php }}"


### PR DESCRIPTION
## Description

A number of predefined actions have had major release, which warrant an update the workflow(s).

These updates don't actually contain any changed functionality, they are mostly just a change of the Node version used by the action itself (from Node 14 to Node 16).

Refs:
* https://github.com/actions/checkout/releases

## How has this been tested?

Will be automatically tested via the CI run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
