### PR TITLE
GH Actions: version update for actions/cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
 
     - name: "Cache Composer dependencies"
       if: steps.should-cache.outputs.do-cache == 1
-      uses: "actions/cache@v2"
+      uses: "actions/cache@v3"
       with:
         path: "${{ steps.composer.outputs.cache-dir }}"
         key: "${{ steps.cache-key.outputs.key }}"


### PR DESCRIPTION
## Description
A number of predefined actions have had major releases, which warrant an update.

The update doesn't actually contain any changed functionality, it's mostly just a change of the Node version used by the action itself (from Node 12 to Node 16), but see the changelog for more info.

Refs:
* https://github.com/actions/cache/releases/

## Motivation and context
Keeping up to date.

## How has this been tested?
Tested via the GH Actions integration tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
