### PR TITLE
GH Actions: version update for codecov action runner

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -79,7 +79,7 @@ jobs:
       - name: "Run expect tests"
         run: "bashcov --root ./bin -- ./tests/bash-test.sh tests/tests.sh"
       - name: "Publish coverage report to Codecov"
-        uses: "codecov/codecov-action@v2"
+        uses: "codecov/codecov-action@v3"
         with:
           files: "./bin/coverage/codecov-result.json"
 


### PR DESCRIPTION
## Description

Yet another predefined action has had a major release.

This is, again, mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

Refs:
* https://github.com/codecov/codecov-action/releases

---

@ramsey As an alternative to these kind of (manual) PRs, I'd be happy to add a Dependabot configuration which will create these type of PRs automatically.



## Motivation and context
General maintenance.

## How has this been tested?
Will automatically be tested via the GH Actions run.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
