### PR TITLE
Fix finding composer cache dir

### DIFF
--- a/bin/composer_paths.sh
+++ b/bin/composer_paths.sh
@@ -46,7 +46,7 @@ if [ ! -f "${composer_lock}" ]; then
 fi
 
 composer_version="$($composer_path --version)"
-cache_dir="$($composer_path config cache-dir)"
+cache_dir="$($composer_path --working-dir "${working_directory}" config cache-dir)"
 
 echo "::debug::Composer path is '${composer_path}'"
 echo "::debug::${composer_version}"

--- a/bin/composer_paths.sh
+++ b/bin/composer_paths.sh
@@ -46,7 +46,7 @@ if [ ! -f "${composer_lock}" ]; then
 fi
 
 composer_version="$($composer_path --version)"
-cache_dir="$($composer_path --working-dir "${working_directory}" config cache-dir)"
+cache_dir="$($composer_path --working-dir="${working_directory}" config cache-dir)"
 
 echo "::debug::Composer path is '${composer_path}'"
 echo "::debug::${composer_version}"

--- a/tests/expect/composer_paths_10.exp
+++ b/tests/expect/composer_paths_10.exp
@@ -1,0 +1,18 @@
+#!/usr/bin/env -S expect -f
+
+set timeout 3
+cd .. # So we don't find a composer.lock in current dir
+spawn ../bin/composer_paths.sh "" "fixtures/with-lock-file"
+match_max 100000
+
+expect "::debug::Composer path is '*'\r
+::debug::Composer version *\r
+::debug::Composer cache directory found at '*composer*'\r
+::debug::File composer.json found at 'fixtures/with-lock-file/composer.json'\r
+::debug::File composer.lock path computed as 'fixtures/with-lock-file/composer.lock'\r
+::set-output name=command::*\r
+::set-output name=cache-dir::*\r
+::set-output name=json::fixtures/with-lock-file/composer.json\r
+::set-output name=lock::fixtures/with-lock-file/composer.lock\r
+"
+expect eof

--- a/tests/expect/composer_paths_10.exp
+++ b/tests/expect/composer_paths_10.exp
@@ -11,9 +11,5 @@ expect "::debug::Composer path is '*'\r
 ::debug::Composer cache directory found at '*composer*'\r
 ::debug::File composer.json found at 'fixtures/with-lock-file/composer.json'\r
 ::debug::File composer.lock path computed as 'fixtures/with-lock-file/composer.lock'\r
-::set-output name=command::*\r
-::set-output name=cache-dir::*\r
-::set-output name=json::fixtures/with-lock-file/composer.json\r
-::set-output name=lock::fixtures/with-lock-file/composer.lock\r
 "
 expect eof

--- a/tests/expect/composer_paths_10.exp
+++ b/tests/expect/composer_paths_10.exp
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S expect -f
 
 set timeout 3
-cd .. # So we don't find a composer.lock in current dir
+# So we don't find a composer.lock in current dir
+cd ..
 spawn ../bin/composer_paths.sh "" "fixtures/with-lock-file"
 match_max 100000
 


### PR DESCRIPTION
## Description
Fix missing working dir when getting composer cache dir config
Bumping included composer.phar version to fix CI error – to the minimum that has this [fix](https://github.com/composer/composer/pull/10909)

## Motivation and context
Fixes #225

## How has this been tested?
Tested by manually running composer_paths.sh in a directory where there is no composer.lock
Current tests do not fail because there is another composer.lock in tests dir.
Added another test case, hope it works (:

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
