### PR TITLE
GH Actions: selectively use `fail-fast` with setup-php

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@v2"
         with:
-          php-version: 7.4
+          php-version: 8.1
           tools: composer-normalize
           coverage: none
       - name: "Run Composer normalize"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,6 +47,8 @@ jobs:
           php-version: "latest"
           tools: "composer:${{ matrix.composer-version }}"
           coverage: "none"
+        env:
+          fail-fast: true
       - name: "Run expect tests"
         run: "composer test"
 
@@ -122,6 +124,8 @@ jobs:
           php-version: "latest"
           tools: "composer:${{ matrix.composer-version }}"
           coverage: "none"
+        env:
+          fail-fast: true
 
       - name: "Test: plain install"
         uses: ./
@@ -251,6 +255,8 @@ jobs:
           php-version: "latest"
           tools: "composer:${{ matrix.composer-version }}"
           coverage: "none"
+        env:
+          fail-fast: true
 
       - name: "Test: plain install"
         uses: ./


### PR DESCRIPTION
## Description
I've seen some recent build failures due to the `setup-php` action running into a rate limit and not downloading the required version of Composer. In the case of this action, that would make the test runs worthless.

The `setup-php` action runner defaults to _showing_ these type errors in the logs, but not stopping the workflow run.

So, specifically for those jobs where the Composer version is important, I'm adding the `fail-fast` option to `setup-php` to fail the build if the action runner ran into any errors.

Ref: https://github.com/shivammathur/setup-php#fail-fast-optional

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.

---

### :new: GH Actions: update PHP version for `composer-normalize`

Looks like the `composer-normalize` package has dropped support for PHP < 8.0 as of version `2.29.0`.

Refs:
* https://github.com/ergebnis/composer-normalize/releases/tag/2.29.0
* https://github.com/ergebnis/composer-normalize/pull/998
