### PR TITLE
Update cache action runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
 
     - name: "Cache Composer dependencies"
       if: steps.should-cache.outputs.do-cache == 1
-      uses: "actions/cache@v3"
+      uses: "actions/cache@v4"
       with:
         path: "${{ steps.composer.outputs.cache-dir }}"
         key: "${{ steps.cache-key.outputs.key }}"


### PR DESCRIPTION
## Description
The `actions/cache` package has released version 4.0 which updates the action runner to use Node 20.

Applying this fix gets rid of the following warning which is currently showing in the "Annotations" of workflows using the `ramsey/composer-install` action:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

Note: most action runners have published these types of update in a new major, so that seems to be the best practice. Not sure if this update warrants a new major for `ramsey/composer-install` ?


**Update**: **_From what I've read, I believe this should be released in a new major as otherwise people using this action in self-hosted runners will run into trouble with this change._**

Refs:
* https://github.com/actions/cache/releases/tag/v4.0.0
* https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

## Motivation and context
People don't like to see warnings in their workflows ;-)

## How has this been tested?
Pre-existing automated tests cover this change and the tests pass.

If you look in your own workflows, you can see that without this change, the following annotations (and a dozen more) display:
```
Run unclean (ubuntu-latest, v2)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Run action (ubuntu-latest, highest, v2, tests/fixtures/out-of-sync-lock)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

With this change, the annotations change to:
```
Run unclean (ubuntu-latest, v2)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Run action (ubuntu-latest, highest, v2, tests/fixtures/out-of-sync-lock)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

For this last warning regarding `actions/checkout@v3`, PR #248 is already open, so this is not addressed here.

## Types of changes

**_Not sure what to put here, could be seen as just plain maintenance, could also be seen as a breaking change ?_**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.

Fixes #253
Closes #254