### PR TITLE
Pin cache action version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
 
     - name: "Cache Composer dependencies"
       if: steps.should-cache.outputs.do-cache == 1
-      uses: "actions/cache@v4"
+      uses: "actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809" # v4.2.4
       with:
         path: "${{ steps.composer.outputs.cache-dir }}"
         key: "${{ steps.cache-key.outputs.key }}"


### PR DESCRIPTION
## Description
This pins the cache action to its commit:
0400d5f644dc74513175e3cd8d07132dd4860809
Which is https://github.com/actions/cache/releases/tag/v4.2.4

## Motivation and context
This allows people to enable the strict GitHub setting to only run pinned GitHub Actions. See https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#managing-github-actions-permissions-for-your-organization

## How has this been tested?
This did not change anything really, but was tested internally in our workflows.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
