### PR TITLE
Bump README setup-php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use ramsey/composer-install as step within a job. This example also shows use of
 the [Setup PHP](https://github.com/shivammathur/setup-php) action as a step.
 
 ```yaml
-- uses: "shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f" # 2.37.0
+- uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
   with:
     php-version: "latest"
 - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
@@ -283,7 +283,7 @@ strategy:
 
 steps:
   - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-  - uses: "shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f" # 2.37.0
+  - uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # 2.37.2
     with:
       php-version: "${{ matrix.php }}"
   - uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0


### PR DESCRIPTION
The README documentation has a hashed version of `shivammathur/setup-php` that is currently flagged as having a known vulnerability.

## Description
The README documentation has a hashed version of `shivammathur/setup-php` that is currently flagged as having a known vulnerability [GHSA-pqwm-q9pv-ph8r](https://github.com/shivammathur/setup-php/security/advisories/GHSA-pqwm-q9pv-ph8r).  Updated the hashed version from `2.37.0` --> `2.37.2` [shivammathur/setup-php@2.37.2](https://github.com/shivammathur/setup-php/releases/tag/2.37.2) to ensure the example implementation had the current version and a version that does not have any known vulnerabilities.

I saw that DependaBot already has an open PR for updating the `continuous-integration.yml` so I did not include that change here and limited my PR to the documentation.

## Motivation and context
When I came to the documentation to update an example case, I then got a validation issue from zizmore.  Thankfully, I have zizmore running as part of my CI pipeline, but for other people who come to this documentation to update or implement their actions they should not be provided a hash with known vulnerabilities.

## How has this been tested?
N/A - documentation update

## Types of changes
Non-functional Change

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
